### PR TITLE
Fixed hardcoded PDU length (1500) which is now configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Where each `<option>` can be one of
 	-4		IPv4 only
 	-6		IPv6 only
 	-h		to print a usage message and exit
+	-u <pdulen>	size of max pdu on listened socket (default 65536)
 
 and each `<destination>` should be specified as
 `<addr>[/<port>[/<interval>[,ttl]]]`, where

--- a/read_config.c
+++ b/read_config.c
@@ -48,6 +48,7 @@
 #define FLOWPORT "2000"
 
 #define DEFAULT_SOCKBUFLEN 65536
+#define DEFAULT_PDULEN 65536
 
 #define MAX_PEERS 100
 #define MAX_LINELEN 8000
@@ -672,6 +673,7 @@ parse_args (argc, argv, ctx)
   sctx->next = (struct source_context *) NULL;
 
   ctx->sockbuflen = DEFAULT_SOCKBUFLEN;
+  ctx->pdulen = DEFAULT_PDULEN;
   ctx->faddr_spec = 0;
   bzero (&ctx->faddr, sizeof ctx->faddr);
   ctx->fport_spec = FLOWPORT;
@@ -690,12 +692,15 @@ parse_args (argc, argv, ctx)
   sctx->tx_delay = 0;
 
   optind = 1;
-  while ((i = getopt (argc, (char **) argv, "hb:d:m:p:s:x:c:fSn46")) != -1)
+  while ((i = getopt (argc, (char **) argv, "hu:b:d:m:p:s:x:c:fSn46")) != -1)
     {
       switch (i)
 	{
 	case 'b': /* buflen */
 	  ctx->sockbuflen = atol (optarg);
+	  break;
+	case 'u': /* pdu length */
+	  ctx->pdulen = atol (optarg);
 	  break;
 	case 'd': /* debug */
 	  ctx->debug = atoi (optarg);
@@ -783,6 +788,7 @@ Supported options:\n\
   -4                       IPv4 only\n\
   -6                       IPv6 only\n\
   -h                       print this usage message and exit\n\
+  -u <pdulen>              size of max pdu on listened socket (default 65536)\n\
 \n\
 Specifying receivers:\n\
 \n\

--- a/samplicate.c
+++ b/samplicate.c
@@ -37,8 +37,6 @@
 #include "rawsend.h"
 #include "inet.h"
 
-#define PDU_SIZE 1500
-
 static int send_pdu_to_receiver (struct receiver *, const void *, size_t,
 				 struct sockaddr *);
 static int init_samplicator (struct samplicator_context *);
@@ -318,7 +316,7 @@ static int
 samplicate (ctx)
      struct samplicator_context *ctx;
 {
-  unsigned char fpdu[PDU_SIZE];
+  unsigned char fpdu[ctx->pdulen];
   struct sockaddr_storage remote_address;
   struct source_context *sctx;
   unsigned i;
@@ -331,17 +329,17 @@ samplicate (ctx)
     {
       addrlen = sizeof remote_address;
       if ((n = recvfrom (ctx->fsockfd, (char*)fpdu,
-			 sizeof (fpdu), 0,
+			 sizeof (fpdu), MSG_TRUNC,
 			 (struct sockaddr *) &remote_address, &addrlen)) == -1)
 	{
 	  fprintf (stderr, "recvfrom(): %s\n", strerror(errno));
 	  exit (1);
 	}
-      if (n > PDU_SIZE)
+      if (n > ctx->pdulen)
 	{
 	  fprintf (stderr, "Warning: %d excess bytes discarded\n",
-		   n-PDU_SIZE);
-	  n = PDU_SIZE;
+		   n-ctx->pdulen);
+	  n = ctx->pdulen;
 	}
       if (addrlen != ctx->fsockaddrlen)
 	{

--- a/samplicator.h
+++ b/samplicator.h
@@ -20,6 +20,7 @@ struct samplicator_context {
   struct sockaddr_storage	faddr;
   const char		       *fport_spec;
   long				sockbuflen;
+  long				pdulen;
   int				debug;
   int				fork;
   int				ipv4_only;


### PR DESCRIPTION
fixes #34 
Deleted PDU_SIZE contant and added configurable option instead.
Added MSG_TRUNC flag to recvfrom, to report datagram truncation