### PR TITLE
Fix source address spoofing to work on FreeBSD systems (was buggy)

### DIFF
--- a/rawsend.c
+++ b/rawsend.c
@@ -120,7 +120,7 @@ raw_send_from_to (s, msg, msglen, saddr_generic, daddr_generic, ttl, flags)
      BSD-derivatives require host byte order, but at least OpenBSD
      since version 2.1 uses network byte order.  Linux uses network
      byte order for all IP header fields. */
-#if defined (__linux__) || (defined (__OpenBSD__) && (OpenBSD > 199702))
+#if defined (__linux__) || (defined (__OpenBSD__) && (OpenBSD > 199702)) || defined(__FreeBSD__)
   ih.ip_len = htons (length);
   ih.ip_off = htons (0);
 #else 


### PR DESCRIPTION
This trivial patch fix the spoofing function under FreeBSD (-S).
On FreeBSD 11.1 this trigger invalid argument.
Regards